### PR TITLE
events: whitelisted some turkish letters

### DIFF
--- a/userbot/events.py
+++ b/userbot/events.py
@@ -23,7 +23,7 @@ def register(**args):
     pattern = args.get('pattern', None)
     disable_edited = args.get('disable_edited', False)
     ignore_unsafe = args.get('ignore_unsafe', False)
-    unsafe_pattern = r'^[^/!#@\$A-Za-z,?]'
+    unsafe_pattern = r'^[^/!#@\$A-Za-z,?İşŞğĞüÜöÖIıÇç]'
     groups_only = args.get('groups_only', False)
     trigger_on_fwd = args.get('trigger_on_fwd', False)
     disable_errors = args.get('disable_errors', False)


### PR DESCRIPTION
Added some turkish letters to the list of unsafe_pattern because they were triggering the userbot if a message started with one of them.